### PR TITLE
wrap values in `{}` to allow objects

### DIFF
--- a/lib/rollup-runtime.js
+++ b/lib/rollup-runtime.js
@@ -22,7 +22,7 @@ module.exports = async function build (layout, page, props, ssr) {
           ]
         }),
         replace({
-          __props__attrs__: Object.entries(props).map(([ key, value ]) => `${key}=${JSON.stringify(value)}`).join(' '),
+          __props__attrs__: Object.entries(props).map(([ key, value ]) => `${key}={${JSON.stringify(value)}}`).join(' '),
           __props__hash__: JSON.stringify(props)
         }),
         svelte({


### PR DESCRIPTION
in order for properties to allow plain JS objects the property values need to be wrapped in `{}`

before:
```svelte
<!-- valid -->
<component key=42 />
<component key="foo" />
<!-- invalid -->
<component key={ "foo": "bar" } />
```
after:
```svelte
<!-- valid -->
<component key={42} />
<component key={"foo"} />
<component key={{ "foo": "bar" }} />
```